### PR TITLE
Adding callable method to the fields option in the fieldset type

### DIFF
--- a/Form/FieldsetType.php
+++ b/Form/FieldsetType.php
@@ -20,6 +20,10 @@ class FieldsetType extends AbstractType {
             'virtual'   => true,
             'options'   => array(),
             'fields'    => array(),
+            'label'     => false,
+        ))
+        ->addAllowedTypes(array(
+            'fields' => array('array', 'callable'),
         ));
     }
 
@@ -30,9 +34,13 @@ class FieldsetType extends AbstractType {
     public function buildForm ( FormBuilderInterface $builder, array $options )
     {
         if ( !empty($options['fields']) ) {
-
-            foreach ( $options['fields'] as $field ) {
-                $builder->add($field['name'], $field['type'], $field['attr']);
+            if ( is_callable($options['fields']) ) {
+                $options['fields']($builder);
+            }
+            elseif ( is_array($options['fields']) ) {
+                foreach ( $options['fields'] as $field ) {
+                    $builder->add($field['name'], $field['type'], $field['attr']);
+                }
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -22,9 +22,24 @@ Register in `app/AppKernel.php`:
 
 Use with normal form builder methods:
 
-    $builder->add('my_group', 'fieldset', [
-
+    // A fieldset with your fields defined in a callback function
+    $builder->add('my_group_example_one', 'fieldset', [
         'label' => false, // You probably don't want a label as well as a legend.
+        'legend' => 'Your fieldset legend',
+        'fields' => function(FormBuilderInterface $builder) {
+            $builder->add('first_name', 'text', [
+                'label' => 'First Name'
+            ]);
+            $builder->add('last_name', 'text', [
+                'required'  => false,
+                'label'     => 'Surname'
+            ]);
+        }
+    ]);
+
+    // A fieldset with your fields defined in an array
+    $builder->add('my_group_example_two', 'fieldset', [
+        'label' => false,
         'legend' => 'Your fieldset legend',
         'fields' => [
             [

--- a/README.md
+++ b/README.md
@@ -8,54 +8,57 @@ Install via composer from `adamquaile/symfony-fieldset-bundle`.
 
 Register in `app/AppKernel.php`:
 
-    public function registerBundles()
-    {
-        $bundles = array(
-            // ...
-            new AdamQuaile\Bundle\FieldsetBundle\AdamQuaileFieldsetBundle(),
-        );
+```php
+public function registerBundles()
+{
+    $bundles = array(
+        // ...
+        new AdamQuaile\Bundle\FieldsetBundle\AdamQuaileFieldsetBundle(),
+    );
 
-        //...
-    }
-
+    //...
+}
+```
 ## Usage
 
 Use with normal form builder methods:
 
-    // A fieldset with your fields defined in a callback function
-    $builder->add('my_group_example_one', 'fieldset', [
-        'label' => false, // You probably don't want a label as well as a legend.
-        'legend' => 'Your fieldset legend',
-        'fields' => function(FormBuilderInterface $builder) {
-            $builder->add('first_name', 'text', [
+```php
+// A fieldset with your fields defined in a callback function
+$builder->add('my_group_example_one', 'fieldset', [
+    'label' => false, // You probably don't want a label as well as a legend.
+    'legend' => 'Your fieldset legend',
+    'fields' => function(FormBuilderInterface $builder) {
+        $builder->add('first_name', 'text', [
+            'label' => 'First Name'
+        ]);
+        $builder->add('last_name', 'text', [
+            'required'  => false,
+            'label'     => 'Surname'
+        ]);
+    }
+]);
+
+// A fieldset with your fields defined in an array
+$builder->add('my_group_example_two', 'fieldset', [
+    'label' => false,
+    'legend' => 'Your fieldset legend',
+    'fields' => [
+        [
+            'name'  => 'first_name',
+            'type'  => 'text',
+            'attr'  => [
                 'label' => 'First Name'
-            ]);
-            $builder->add('last_name', 'text', [
+            ]
+        ],
+        [
+            'name'  => 'last_name',
+            'type'  => 'text',
+            'attr'  => [
                 'required'  => false,
                 'label'     => 'Surname'
-            ]);
-        }
-    ]);
-
-    // A fieldset with your fields defined in an array
-    $builder->add('my_group_example_two', 'fieldset', [
-        'label' => false,
-        'legend' => 'Your fieldset legend',
-        'fields' => [
-            [
-                'name'  => 'first_name',
-                'type'  => 'text',
-                'attr'  => [
-                    'label' => 'First Name'
-                ]
-            ],
-            [
-                'name'  => 'last_name',
-                'type'  => 'text',
-                'attr'  => [
-                    'required'  => false,
-                    'label'     => 'Surname'
-                ]
             ]
         ]
-    ]);
+    ]
+]);
+```


### PR DESCRIPTION
A nice way of passing your sub types to the fieldset as an alternative to arrays.

See [Issue #6584](https://github.com/symfony/symfony/issues/6584#issuecomment-139837107) on [symfony/symfony](https://github.com/symfony/symfony)